### PR TITLE
UI: Add test for UIManager.clear and limit iteration to direct children

### DIFF
--- a/arcade/gui/ui_manager.py
+++ b/arcade/gui/ui_manager.py
@@ -87,6 +87,7 @@ class UIManager(EventDispatcher, UIWidgetParent):
         for children in self.children.values():
             if child in children:
                 children.remove(child)
+                child.parent = None
                 self.trigger_render()
 
     def walk_widgets(self, *, root: UIWidget = None) -> Iterable[UIWidget]:
@@ -96,6 +97,14 @@ class UIManager(EventDispatcher, UIWidgetParent):
         for child in reversed(children):
             yield from self.walk_widgets(root=child)
             yield child
+
+    def clear(self):
+        """
+        Remove all widgets from UIManager
+        """
+        for layer in self.children.values():
+            for widget in layer:
+                self.remove(widget)
 
     def get_widgets_at(self, pos, cls=UIWidget) -> Iterable[W]:
         """
@@ -151,13 +160,6 @@ class UIManager(EventDispatcher, UIWidgetParent):
                     child._do_render(surface, force)
 
         self._rendered = True
-    
-    def clear(self):
-      """
-      Clears the container
-      """
-      for widget in self.walk_widgets():
-          self.remove(widget)
 
     def enable(self):
         """

--- a/tests/test_gui/test_uimanager.py
+++ b/tests/test_gui/test_uimanager.py
@@ -52,3 +52,25 @@ def test_get_top_widget_by_cls(window):
 
     children = list(manager.get_widgets_at(pos=(100, 100), cls=MyUIDummy))
     assert children == [widget2]
+
+
+def test_remove_child_and_clear_parent_property(window):
+    manager = UIManager()
+    widget1 = UIDummy()
+    manager.add(widget1)
+
+    manager.remove(widget1)
+
+    assert widget1.parent is None
+    assert list(manager.walk_widgets()) == []
+
+
+def test_clear_removes_all_children(window):
+    manager = UIManager()
+    widget1 = UIDummy(x=50, y=50, width=100, height=100)
+    manager.add(widget1)
+
+    manager.clear()
+
+    assert widget1.parent is None
+    assert list(manager.walk_widgets()) == []


### PR DESCRIPTION
Hi,

it would be a good idea, to iterate only over the direct children of the UIManager.

I also added a few tests and cleaning up, the parent property on the child. If you merge these changes, I will accept your PR to arcade :)

Let me know if this is fine for you.